### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PyPi Release](https://img.shields.io/pypi/v/mercuryitc.svg)](https://img.shields.io/pypi/v/mercuryitc.svg)
+
 # MercuryITC driver
 
 ## About

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -559,11 +559,7 @@ class MercuryITC_LOOP(MercuryModule):
 
     @t_setpoint.setter
     def t_setpoint(self, val):
-        hotl = convert_scaled_values(self._read_cached_property('CAL:HOTL', str))
-        if 0 <= val <= hotl[0]:
-            self._write_property('TSET', val, float)
-        else:
-            raise ValueError('Only values between 0K and %sK allowed' % hotl[0])
+        self._write_property('TSET', val, float)
 
     @property
     def flow(self):

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -553,7 +553,7 @@ class MercuryITC_LOOP(MercuryModule):
 
     @property
     def t_setpoint(self):
-        """Temperature setpoint for PID loop - Read/set - Float value [0 to HOTL]"""
+        """Temperature setpoint for PID loop - Read/set - Float value"""
         resp = convert_scaled_values(self._read_property('TSET', str))
         return resp[0]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from mercuryitc import __version__
 # Sam Schott <ss2151@cam.ac.uk>
 
 setup(name="mercuryitc",
-      version=__version__',
+      version=__version__,
       description="Full Python driver for the Oxford Mercury iTC cryogenic environment controller.",
       author='Florian Forster, Sam Schott',
       maintainer='Florian Forster',


### PR DESCRIPTION
- Fixed a leftover quotation mark in setup.py
- Removed checking for hot limit when setting the t_setpoint. This does not work, since CAL_HOTL is a property of the parent temperature sensor, and not the control loop itself.
- Added shield linking to PyPi release.