### PR TITLE
Allow keyword arguments to be passed on to PyVisa connection

### DIFF
--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -750,7 +750,7 @@ class MercuryITC(MercuryCommon):
 
     address = 'SYS'
 
-    def __init__(self, visa_address, visa_library='@py'):
+    def __init__(self, visa_address, visa_library='@py', **kwargs):
         super(MercuryITC, self).__init__()
         self.visa_address = visa_address
         self.visa_library = visa_library
@@ -760,12 +760,12 @@ class MercuryITC(MercuryCommon):
     def __repr__(self):
         return '<%s(%s)>' % (type(self).__name__, self.visa_address)
 
-    def connect(self):
+    def connect(self, **kwargs):
 
         connection_error = OSError if PY2 else ConnectionError
 
         try:
-            self.connection = self.rm.open_resource(self.visa_address)
+            self.connection = self.rm.open_resource(self.visa_address, **kwargs)
             self.connection.read_termination = '\n'
             self.connected = True
             self._init_modules()

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -755,7 +755,7 @@ class MercuryITC(MercuryCommon):
         self.visa_address = visa_address
         self.visa_library = visa_library
         self.rm = visa.ResourceManager(self.visa_library)
-        self.connect()
+        self.connect(**kwargs)
 
     def __repr__(self):
         return '<%s(%s)>' % (type(self).__name__, self.visa_address)


### PR DESCRIPTION
Small tweak to allow keyword arguments passed to the constructor to be passed on to the PyVisa connection. This allows for instance to select an `open_timeout` or `baud_rate` for the connection.