### PR TITLE
minor improvements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.2.2  04.12.2019 -- Remember PyVisa connection settings passed to constructor between disconnects. Improved thread safety.
 v0.2.1, 30.04.2019 -- Mooved controls for LOOP module to TEMP module.
 v0.2.0, 09.02.2019 -- Use pyvisa as communication protocol, added support for LOOP module, singleton behaviour when instanciating the device (all credit goes to Sam Schott for this release)
 v0.1.0, 18.03.2014 -- Initial release.

--- a/mercuryitc/__init__.py
+++ b/mercuryitc/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 from mercuryitc.mercury_driver import MercuryITCFactory as MercuryITC

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -788,6 +788,7 @@ class MercuryITC(MercuryCommon):
         super(MercuryITC, self).__init__()
         self.visa_address = visa_address
         self.visa_library = visa_library
+        self._connection_kwargs = kwargs
         self.rm = visa.ResourceManager(self.visa_library)
         self.connect(**kwargs)
 
@@ -796,6 +797,7 @@ class MercuryITC(MercuryCommon):
 
     def connect(self, **kwargs):
 
+        kwargs = kwargs or self._connection_kwargs  # use specified or remembered kwargs
         connection_error = OSError if PY2 else ConnectionError
 
         try:

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -841,11 +841,12 @@ class MercuryITC(MercuryCommon):
                 self.modules.append(MercuryITC_HTR(address, self))
 
     def write(self, q):
-        self.connection.write(q)
+        with self._lock:
+            self.connection.write(q)
 
     def read(self):
-        value = self.connection.read()
-        return value
+        with self._lock:
+            return self.connection.read()
 
     def query(self, q):
         with self._lock:


### PR DESCRIPTION
- Remember PyVisa connection settings passed to the constructor. If the user manually calls `Keithley.connect`, the same settings are used by default unless otherwise specified.

- Improve thread safety: perform reads and writes with `RLock` to prevent interfering with queries.