### PR TITLE
A few bug fixes and consistency improvements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
+v0.2.3  21.07.2020 -- Fixed a possible issue when parsing alarms, set connection to None if not connected, improved thread safety when connecting to or disconnecting from device.
 v0.2.2  04.12.2019 -- Remember PyVisa connection settings passed to constructor between disconnects. Improved thread safety.
-v0.2.1, 30.04.2019 -- Mooved controls for LOOP module to TEMP module.
-v0.2.0, 09.02.2019 -- Use pyvisa as communication protocol, added support for LOOP module, singleton behaviour when instanciating the device (all credit goes to Sam Schott for this release)
+v0.2.1, 30.04.2019 -- Moved controls for LOOP module to TEMP module.
+v0.2.0, 09.02.2019 -- Use pyvisa as communication protocol, added support for LOOP module, singleton behaviour when instantiating the device (all credit goes to Sam Schott for this release)
 v0.1.0, 18.03.2014 -- Initial release.

--- a/mercuryitc/__init__.py
+++ b/mercuryitc/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 
 from mercuryitc.mercury_driver import MercuryITCFactory as MercuryITC

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -996,9 +996,9 @@ class MercuryITC(MercuryCommon):
     @property
     def alarms(self):
         """Gets the system alarms log"""
-        string = self._read_property('ALRM', str)
-        alarm_list = string[:-1].split(';')
-        alarms_dict = dict(item.split('\t') for item in alarm_list)
+        value = self._read_property('ALRM', str)
+        string_list = value.split(';')
+        alarms_dict = dict(s.split('\t') for s in string_list if s)
         return alarms_dict
 
 

--- a/mercuryitc/mercury_driver.py
+++ b/mercuryitc/mercury_driver.py
@@ -779,8 +779,8 @@ class MercuryITC(MercuryCommon):
     DIMAS = ['ON', 'OFF']
     _lock = threading.RLock()
 
-    connected = True
-    connection = False
+    connected = False
+    connection = None
 
     address = 'SYS'
 
@@ -823,7 +823,7 @@ class MercuryITC(MercuryCommon):
         self.connected = False
         try:
             self.connection.close()
-            del self.connection
+            self.connection = None
         except AttributeError:
             pass
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 # Sam Schott <ss2151@cam.ac.uk>
 
 setup(name="mercuryitc",
-      version='0.2.2',
+      version='0.2.3',
       description="Full Python driver for the Oxford Mercury iTC cryogenic environment controller.",
       author='Florian Forster, Sam Schott',
       maintainer='Florian Forster',


### PR DESCRIPTION
This is a bug fix PR:

* Fixes a possible issue when parsing alarms when the returned string contains empty semicolon-delimited fields
* Always sets the `connection` attribute to `None` if not connected. This previously was inconsistent.
* Improves thread safety when connecting to or disconnecting from device.
* Raises a `ConnectionError` when when trying to write or read while no device is connected. Previously, an `AttributeError` was raised.